### PR TITLE
Add jq install instructions to system overview guide

### DIFF
--- a/raspibolt/raspibolt_61_system-overview.md
+++ b/raspibolt/raspibolt_61_system-overview.md
@@ -17,6 +17,7 @@ To get a quick overview over the system status, I created [a shell script](https
 This script will run as root, so please check it before blindly trusting me.
 
 ```
+$ sudo apt-get install jq
 $ cd /home/admin/download/
 $ wget https://raw.githubusercontent.com/Stadicus/guides/master/raspibolt/resources/20-raspibolt-welcome
   


### PR DESCRIPTION
It doesn't come pre-installed:

```
/usr/local/bin/raspibolt: 57: /usr/local/bin/raspibolt: jq: not found
/usr/local/bin/raspibolt: 63: /usr/local/bin/raspibolt: jq: not found
expr: syntax error
/usr/local/bin/raspibolt: 66: /usr/local/bin/raspibolt: jq: not found
/usr/local/bin/raspibolt: 69: [: -eq: unexpected operator
/usr/local/bin/raspibolt: 73: [: -eq: unexpected operator
/usr/local/bin/raspibolt: 77: [: -le: unexpected operator
/usr/local/bin/raspibolt: 94: /usr/local/bin/raspibolt: jq: not found
/usr/local/bin/raspibolt: 105: [: =: unexpected operator
/usr/local/bin/raspibolt: 112: /usr/local/bin/raspibolt: jq: not found
```