### PR TITLE
Bug? block_diff

### DIFF
--- a/raspibolt/resources/20-raspibolt-welcome
+++ b/raspibolt/resources/20-raspibolt-welcome
@@ -63,7 +63,7 @@ if [ -n ${btc_path} ]; then
     btc_title="${btc_title} (${chain}net)"
 
     # get sync status
-    block_chain="$(bitcoin-cli -datadir=${bitcoin_dir} getblockcount)"
+    block_chain="$(bitcoin_cli -datadir=${bitcoin_dir} getblockchaininfo | jq -r '.headers')"
     block_verified="$(bitcoin-cli -datadir=${bitcoin_dir} getblockchaininfo | jq -r '.blocks')"
     block_diff=$(expr ${block_chain} - ${block_verified})
 


### PR DESCRIPTION
I had to make the change indicated to correctly show how far behind my bitcoind was when syncing the mainchain on my Raspibolt.
 (I was doing this just for testing)

At the point where I had downloaded and verified only 7% of the blockchain, the output of the 3 commands in question were:

* getblockcount = 260724
* getblockchaininfo -> headers = 518291
* getblockchaininfo -> blocks = 260580

Here are the full outputs ( as few seconds apart)

admin ~  ฿  bitcoin-cli -conf=/home/bitcoin/.bitcoin/bitcoin.conf getblockcount
260724

admin ~  ฿  bitcoin-cli -conf=/home/bitcoin/.bitcoin/bitcoin.conf getblockchaininfo
{
  "chain": "main",
  "blocks": 260580,
  "headers": 518291,
....
  "verificationprogress": 0.0768998938604351,
...
}