### PR TITLE
Restarts lnd if externalip changes

### DIFF
--- a/raspibolt/raspibolt_40_lnd.md
+++ b/raspibolt/raspibolt_40_lnd.md
@@ -19,11 +19,17 @@ To announce our public IP address to the Lightning network, we first need to get
 # /usr/local/bin/getpublicip.sh
 
 echo 'getpublicip.sh started, writing public IP address every 10 minutes into /run/publicip'
-while [ 0 ];
-    do
-    printf "PUBLICIP=$(curl -vv ipinfo.io/ip 2> /run/publicip.log)\n" > /run/publicip;
-    sleep 600
+while [ 0 ];do
+ source /run/publicip
+ CURRENTIP=$(curl ipinfo.io/ip 2> /run/publicip.log )
+ echo  PUBLICIP=$CURRENTIP > /run/publicip;
+ if [ "$CURRENTIP" != "$PUBLICIP" ];then
+  echo Restarting lnd.service New external IP = $CURRENTIP
+  sudo /bin/systemctl restart lnd.service
+ fi
+ sleep 600
 done;
+
 ```
 * make it executable  
   `$ sudo chmod +x /usr/local/bin/getpublicip.sh`


### PR DESCRIPTION
As it is not clear if/when we will get a fix to lncli that allows updating externalip on the fly, at this point in time .. this is the next best.

If externalip changes and not restarted lnd becomes pretty useless as this node becomes invisible on the LN. 

Needless to say ... this locks the wallet .... and a possible solution is here:
https://github.com/robclark56/RaspiBolt-Extras/blob/master/RB_extra_01.md