### PR TITLE
added flags to systemd bitcoind.service file

### DIFF
--- a/raspibolt/raspibolt_30_bitcoin.md
+++ b/raspibolt/raspibolt_30_bitcoin.md
@@ -128,7 +128,7 @@ User=bitcoin
 Group=bitcoin
 Type=forking
 PIDFile=/home/bitcoin/.bitcoin/bitcoind.pid
-ExecStart=/usr/local/bin/bitcoind -pid=/home/bitcoin/.bitcoin/bitcoind.pid
+ExecStart=/usr/local/bin/bitcoind -daemon -conf=/home/bitcoin/.bitcoin/bitcoin.conf -pid=/home/bitcoin/.bitcoin/bitcoind.pid
 KillMode=process
 Restart=always
 TimeoutSec=120


### PR DESCRIPTION
i needed to add the `-daemon` flag to make the systemd job not hang and crash. Also added the `-conf` flag for more precise. Was there a reason you omitted these? If no, here is a pull-req.

might it also be good idea to add the hardening configs as suggested in official [bitcoin systemd file](https://github.com/bitcoin/bitcoin/blob/master/contrib/init/bitcoind.service#L23-L41) ?