### PR TITLE
Fix `swapon: /mnt/hdd/swapfile: read swap header failed`

### DIFF
--- a/raspibolt/raspibolt_20_pi.md
+++ b/raspibolt/raspibolt_20_pi.md
@@ -282,13 +282,13 @@ CONF_SWAPSIZE=1000
 ```
 
 * Delete the old swap file  
-  `$ sudo dphys-swapfile swapoff`
-  `$ sudo rm /var/swap`
+  `$ sudo dphys-swapfile swapoff`  
+  `$ sudo rm /var/swap`  
 
-* Manually create new swap file
-  `$ sudo dd if=/dev/zero of=/mnt/hdd/swapfile count=1000 bs=1MiB`
-  `$ sudo chmod 600 /mnt/hdd/swapfile`
-  `$ sudo mkswap /mnt/hdd/swapfile`
+* Manually create new swap file  
+  `$ sudo dd if=/dev/zero of=/mnt/hdd/swapfile count=1000 bs=1MiB`  
+  `$ sudo chmod 600 /mnt/hdd/swapfile`  
+  `$ sudo mkswap /mnt/hdd/swapfile`  
 
 * Enable new swap configuration  
   `$ sudo dphys-swapfile setup`  

--- a/raspibolt/raspibolt_20_pi.md
+++ b/raspibolt/raspibolt_20_pi.md
@@ -285,6 +285,11 @@ CONF_SWAPSIZE=1000
   `$ sudo dphys-swapfile swapoff`
   `$ sudo rm /var/swap`
 
+* Manually create new swap file
+  `$ sudo dd if=/dev/zero of=/mnt/hdd/swapfile count=1000 bs=1MiB`
+  `$ sudo chmod 600 /mnt/hdd/swapfile`
+  `$ sudo mkswap /mnt/hdd/swapfile`
+
 * Enable new swap configuration  
   `$ sudo dphys-swapfile setup`  
   `$ sudo dphys-swapfile swapon`


### PR DESCRIPTION
I was getting this error at the swapon step. Manually creating the swapfile seemed to work. For reference see https://www.raspberrypi.org/forums/viewtopic.php?p=251251.

This fixes #105.