### PR TITLE
Add check to see if IP:PORT is open for inactive channels

### DIFF
--- a/raspibolt/resources/lnchannels
+++ b/raspibolt/resources/lnchannels
@@ -59,10 +59,15 @@ printf "%-21s %12s %5s %12s %12s %6s %5s\n" 'Alias or Pubkey' 'Capacity' 'Fee' '
 horiz_line="-------------------- ------------- ------ ------------ ------------ ----- ------"
 echo $horiz_line
 for (( i=0; i<=$(( $total -1 )); i++ ));do
+ addr_port=$(${lncli} getnodeinfo ${a_remote_pubkey[$i]} | jq -r .node.addresses[0].addr)
+ addr=${addr_port/:/ }
  if [ ${a_active[$i]} == 'true' ];  then
   color_line=${color_gray}
+  public_check=''
  else
   color_line=${color_red}
+  public_check=$(timeout 2s nc -z ${addr}; echo $?)
+  if [ "${public_check}" == '0' ];then public_check='';else public_check='X';fi
  fi
  alias=$(${lncli} getnodeinfo ${a_remote_pubkey[$i]} | jq -r .node.alias)
  if [ "${alias}" == "" ] ; then
@@ -83,6 +88,7 @@ for (( i=0; i<=$(( $total -1 )); i++ ));do
  total_fee=$(( ${total_fee} + ${a_commit_fee[$i]} ))
  total_local=$(( ${total_local} + ${a_local_balance[$i]} ))
  total_remote=$(( ${total_remote} + ${a_remote_balance[$i]} ))
+ if [ ${#public_check} != 0 ] ; then echo " > No response from Addr:Port ${addr_port}";fi
 done
 printf "${color_yellow}%s\n" "${horiz_line}"
 printf "Totals%14s %13s %6s %12s %12s Day: %7s\n" \

--- a/raspibolt/resources/lnchannels
+++ b/raspibolt/resources/lnchannels
@@ -66,7 +66,8 @@ for (( i=0; i<=$(( $total -1 )); i++ ));do
   public_check=''
  else
   color_line=${color_red}
-  public_check=$(timeout 2s nc -z ${addr}; echo $?)
+  public_check='0';
+  if [ "$addr" != 'null' ]; then public_check=$(timeout 2s nc -z ${addr}; echo $?);fi
   if [ "${public_check}" == '0' ];then public_check='';else public_check='X';fi
  fi
  alias=$(${lncli} getnodeinfo ${a_remote_pubkey[$i]} | jq -r .node.alias)


### PR DESCRIPTION
Enhancement to lnchannels to show if a node is not responding if a channel is inactive

In this example:

*  Channels to KRYPTO.KOELN are inactive, but the node seems active
*  Channels to _poole_party_ and _Stadicus RaspiBolt_ are inactive, and the nodes seem down (?)

![image](https://user-images.githubusercontent.com/12369926/42730523-d81ab18e-8828-11e8-94e2-f5c24203ccf7.png)


