### PR TITLE
Add information on 32 bit Bitcoin version download

### DIFF
--- a/raspibolt/raspibolt_30_bitcoin.md
+++ b/raspibolt/raspibolt_30_bitcoin.md
@@ -18,7 +18,7 @@ We will download the software directly from bitcoin.org, verify its signature to
 
 We download the latest Bitcoin Core binaries (the application) and compare the file with the signed checksum. This is a precaution to make sure that this is an official release and not a malicious version trying to steal our money.
 
-* Get the latest download links at bitcoin.org/en/download, they change with each update. Then run the following  commands (with adjusted filenames) and check the output where indicated:  
+* Get the latest download links at bitcoin.org/en/download (ARM Linux 32 bit), they change with each update. Then run the following  commands (with adjusted filenames) and check the output where indicated:  
   `$ wget https://bitcoin.org/bin/bitcoin-core-0.16.0/bitcoin-0.16.0-arm-linux-gnueabihf.tar.gz`  
   `$ wget https://bitcoin.org/bin/bitcoin-core-0.16.0/SHA256SUMS.asc`  
   `$ wget https://bitcoin.org/laanwj-releases.asc`

--- a/raspibolt/raspibolt_faq.md
+++ b/raspibolt/raspibolt_faq.md
@@ -99,3 +99,5 @@ $ lnd --version
   `$ lncli unlock`  
   `$ sudo journalctl -u lnd -f`  
 
+### Why do I need the 32 bit version of Bitcoin when I have a Raspberry Pi 3 with a 64 bit processor?
+At the time of this writing (July 2018) there is no 64 bit operating system for the Raspberry Pi developed yet. The 64 bit processors of the Raspberry 3 versions are running in 32 bit compatibility mode with a 32 bit operating system.


### PR DESCRIPTION
The latest RPis are running a 32 bit operating system even though they have 64 bit processors. This tripped me up for a moment when downloading the latest version of Bitcoin and may be valuable information for anyone who is not experienced with Raspberry Pi.