### PR TITLE
restart typo removed

### DIFF
--- a/thundroid/README.md
+++ b/thundroid/README.md
@@ -232,7 +232,7 @@ $ sudo dphys-swapfile setup
 $ sudo dphys-swapfile swapon
 
 # reboot, login as "admin" and delete old swapfile
-$ restart shutdown -r now  
+$ shutdown -r now  
 $ sudo rm /var/swap
 ```
 


### PR DESCRIPTION
`shutdown -r now` not `restart shutdown -r now` after setting new swap file.