### PR TITLE
Update testnet faucet link

### DIFF
--- a/raspibolt/raspibolt_40_lnd.md
+++ b/raspibolt/raspibolt_40_lnd.md
@@ -230,7 +230,7 @@ Now your Lightning node is ready. To use it in testnet, you can get some free te
   `> "address": "2NCoq9q7............dkuca5LzPXnJ9NQ"` 
 
 * Get testnet bitcoin:  
-  https://testnet.manu.backend.hamburg/faucet
+  https://testnet-faucet.mempool.co
 
 * Check your LND wallet balance  
   `$ lncli --network=testnet walletbalance`  


### PR DESCRIPTION
As https://testnet.manu.backend.hamburg/faucet has been abandoned and no testnet coins are available from this faucet anymore, here is a new one: https://testnet-faucet.mempool.co
