### PR TITLE
LND autostart (fix?)

### DIFF
--- a/raspibolt/raspibolt_40_lnd.md
+++ b/raspibolt/raspibolt_40_lnd.md
@@ -175,7 +175,7 @@ RestartSec=60
 WantedBy=multi-user.target
 ```
 * enable and start LND  
-  `$ sudo systemctl enable lnd`  
+  `$ sudo systemctl enable lnd.service`  
   `$ sudo systemctl start lnd`  
   `$ systemctl status lnd`  
 


### PR DESCRIPTION
Changed: 
$ sudo systemctl enable lnd
To:
$ sudo systemctl enable lnd.service

Not sure if this is a good commit, cause i'm not 100% sure this actually was my problem so please give some feedback on this one. On my raspibolt the LND client didnt startup at boot without the '.service' behind the line.