### PR TITLE
Update lnchannels

### DIFF
--- a/raspibolt/resources/lnchannels
+++ b/raspibolt/resources/lnchannels
@@ -20,8 +20,8 @@ for i in "$@"
 do
 case $i in
   --testnet*)
-    lncli="${lncli} --rpcserver=localhost:11009"
-    lnd_pid=$(systemctl show -p MainPID lnd_testnet | awk -F"=" '{print $2}')
+    lncli="${lncli} --network=testnet"
+    lnd_pid=$(systemctl show -p MainPID lnd | awk -F"=" '{print $2}')
     chain='test'
     shift # past argument=value
     ;;


### PR DESCRIPTION
For testnet, calling `lncli` with --network=testnet is required as of v0.5. 
--rpcserver=localhost:11009 is not correct for me, works fine without anything.  
PID should be lnd instead of lnd_testnet