### PR TITLE
Update EPS rescan tail to reflect probable second SSH sesseion as mas…

### DIFF
--- a/raspibolt/raspibolt_64_electrum.md
+++ b/raspibolt/raspibolt_64_electrum.md
@@ -114,7 +114,7 @@ The Electrum Personal Server scripts are installed in the directory `/home/bitco
   
   * You can monitor the rescan progress in the Bitcoin Core logfile from a second SSH session:  
     ```
-    $ tail -f /home/bitcoin/.bitcoin/debug.log
+    $ sudo tail -f /home/bitcoin/.bitcoin/debug.log
     ```
 
   * Run Electrum Personal Server again and connect your Electrum wallet from your regular computer.


### PR DESCRIPTION
…ter user

Since I started the second SSH session as the normal admin user, I needed sudo to view the log, otherwise I got a permission denied error.