### PR TITLE
Update `lnd` install version

### DIFF
--- a/raspibolt/raspibolt_40_lnd.md
+++ b/raspibolt/raspibolt_40_lnd.md
@@ -11,25 +11,25 @@ We will now download and install the LND (Lightning Network Daemon) by [Lightnin
 ```
 $ cd /home/admin/download
 $ rm -rf /home/admin/download/*
-$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.5-beta/lnd-linux-armv7-v0.5-beta.tar.gz
-$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.5-beta/manifest-v0.5-beta.txt
-$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.5-beta/manifest-v0.5-beta.txt.sig
+$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.5.2-beta/lnd-linux-armv7-v0.5.2-beta.tar.gz
+$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.5.2-beta/manifest-v0.5.2-beta.txt
+$ wget https://github.com/lightningnetwork/lnd/releases/download/v0.5.2-beta/manifest-v0.5.2-beta.txt.sig
 $ wget https://keybase.io/roasbeef/pgp_keys.asc
 
-$ sha256sum --check manifest-v0.5-beta.txt --ignore-missing
-> lnd-linux-armv7-v0.5-beta.tar.gz: OK
+$ sha256sum --check manifest-v0.5.2-beta.txt --ignore-missing
+> lnd-linux-armv7-v0.5.2-beta.tar.gz: OK
 
 $ gpg ./pgp_keys.asc
 > BD599672C804AF2770869A048B80CD2BB8BD8132
 
 $ gpg --import ./pgp_keys.asc
-$ gpg --verify manifest-v0.5-beta.txt.sig
+$ gpg --verify manifest-v0.5.2-beta.txt.sig
 > gpg: Good signature from "Olaoluwa Osuntokun <laolu32@gmail.com>" [unknown]
 > Primary key fingerprint: BD59 9672 C804 AF27 7086  9A04 8B80 CD2B B8BD 8132
 >      Subkey fingerprint: F803 7E70 C12C 7A26 3C03  2508 CE58 F7F8 E20F D9A2
 
-$ tar -xzf lnd-linux-armv7-v0.5-beta.tar.gz
-$ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-armv7-v0.5-beta/*
+$ tar -xzf lnd-linux-armv7-v0.5.2-beta.tar.gz
+$ sudo install -m 0755 -o root -g root -t /usr/local/bin lnd-linux-armv7-v0.5.2-beta/*
 $ lnd --version
 > lnd version 0.5.0-beta commit=3b2c807288b1b7f40d609533c1e96a510ac5fa6d
 ```


### PR DESCRIPTION
This PR swaps out the `lnd` version to be installed from `..0.5-beta` to `..0.5.2-beta` to include newest changes and bugfixes. The respective changelogs for the new versions can be found at:

- [lnd v0.5.1-beta release](https://github.com/lightningnetwork/lnd/releases/tag/v0.5.1-beta)
- [lnd v0.5.2-beta release](https://github.com/lightningnetwork/lnd/releases/tag/v0.5.2-beta)

No material changes are made to the rest of the install process as far as I can tell by using this newer version. I just updated my node from `0.5` to `0.5.2` and it came back up with all balances and channels intact.