### PR TITLE
Simple Bug Fix on % free storage

### DIFF
--- a/raspibolt/resources/20-raspibolt-welcome
+++ b/raspibolt/resources/20-raspibolt-welcome
@@ -39,7 +39,7 @@ else
 fi
 
 # get storage
-sd_free_ratio=$(printf "%d" "$(df -h | grep "/$" | awk '{ print $4/$2*100 }')") 2>/dev/null
+sd_free_ratio=$(printf "%d" "$(df | grep "/$" | awk '{ print $4/$2*100 }')") 2>/dev/null
 sd=$(printf "%s (%s%%)" "$(df -h | grep '/$' | awk '{ print $4 }')" "${sd_free_ratio}")
 if [ ${sd_free_ratio} -lt 10 ]; then
   color_sd="${color_red}"
@@ -47,7 +47,7 @@ else
   color_sd=${color_green}
 fi
 
-hdd_free_ratio=$(printf "%d" "$(df -h | grep ${ext_hdd} | awk '{ print $4/$2*100 }')") 2>/dev/null
+hdd_free_ratio=$(printf "%d" "$(df  | grep ${ext_hdd} | awk '{ print $4/$2*100 }')") 2>/dev/null
 hdd=$(printf "%s (%s%%)" "$(df -h | grep ${ext_hdd} | awk '{ print $4 }')" "${hdd_free_ratio}")
 
 if [ ${hdd_free_ratio} -lt 10 ]; then


### PR DESCRIPTION
This bug only became apparent when the free space on / fell below 1GB on my SD card

The change is explained by an example

```
$ df -h
/dev/root        14G  8.4G  4.0G  68% /
```
Calculated free space by orig file: 29% = OK

```
$ df -h
/dev/root        14G  8.4G  300M  68% /
```
Calculated free space by orig file: 2143% = Bad

```
$ df
/dev/root       13671000   8799372   300000  68% /
```
Calculated free space by new file: 22% = Good