### PR TITLE
Install additional required Python packages

### DIFF
--- a/raspibolt/raspibolt_64_electrum.md
+++ b/raspibolt/raspibolt_64_electrum.md
@@ -24,8 +24,11 @@ Before using this setup, please familiarize yourself with all components by sett
 
 ### Preparations
 
-* With user 'admin', make sure Python3 and PIP are installed  
-  `$ sudo apt install -y python3 python3-pip`
+* With user 'admin', make sure Python3 and PIP are installed. Also the 'setuptools' package is required.
+  ```
+  $ sudo apt install -y python3 python3-pip
+  $ sudo pip3 install setuptools
+  ```
 
 * Configure firewall to allow incoming requests (please check if you need to adjust the subnet mask as [described in original setup](raspibolt_20_pi.md#enabling-the-uncomplicated-firewall))
   ```
@@ -94,6 +97,8 @@ Electrum Personal Server uses the Bitcoin Core wallet with "watch-only" addresse
 * Install Electrum Personal Server
   ```
   $ cd electrum-personal-server-eps-v0.1.6/
+  # Install the wheel package first, which is required
+  $ pip3 install wheel
   $ pip3 install --user .
   ```
   


### PR DESCRIPTION
There was 2 packages that the latest version of Electrum Personal Server (v0.1.6) required and were not included in the instructions: `setuptools` and `wheel`. I found this to be a problem for some people according to issues in GitHub or comments on Reddit/forums.

I edited the guide according to the steps I followed and worked in my Raspberry (Raspbian). However, there might be a better way to structure those changes.